### PR TITLE
Create a new action to report code coverage during integration

### DIFF
--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -86,14 +86,16 @@ jobs:
       - name: Linting
         run: flutter analyze .
 
-      - name: Running unit tests
-        run: |
-          flutter test test/unit_tests
-
-      - name: Running widget tests
-        run: |
-          flutter test test/widget
-
       - name: Building web application
         run: |
           flutter build web
+
+      - name: Running unit and widget tests with coverage
+        run: |
+          flutter test test/unit_tests test/widget --coverage
+
+      - name: Generate coverage report 
+        uses: fermi-ad/code-coverage-reporter@v1.0.0
+        with:
+          include_pattern: ^.*\.dart$
+          exclude_pattern: test/|\.dart_tool/


### PR DESCRIPTION
I created a new action that can be used to report code coverage on merge requests. I've updated the flutter-integration.yaml file to reflect this. [PR 30](https://github.com/fermi-ad/enclosure-status-app/pull/30) for the Enclosure Status app was my testbed for developing the action, so an example of what its output looks like can be seen there (the last of the posts from the GitHub Actions bot is reflective of what the action does - the previous posts can be ignored). 

Happy to make any changes that people would like to see. This was a project I took on mostly to help familiarize myself with GH Actions and the Flutter codebases, so it need not become part of the global project CI/CD workflow if folks don't find code coverage metrics useful. I personally like to use it as a canary in the coal mine - getting coverage to 100% is not always a good use of developer time, but sharp drops in coverage are good indicators that new code is not being properly tested. 