### PR TITLE
Update chromedriver version

### DIFF
--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -38,7 +38,7 @@ jobs:
           channel: "stable"
           cache: true
 
-      - name: Install Chrome beta
+      - name: Install Chrome
         id: setup-chrome
         uses: browser-actions/setup-chrome@v1
         with:


### PR DESCRIPTION
The version of chromedriver being pulled in does not match the version of chrome on the ubuntu boxes, leading integration tests to fail

Tested this new version in https://github.com/fermi-ad/enclosure-status-app/pull/36 and verified it works as intended