### PR TITLE
Update code coverage plugin version

### DIFF
--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -95,7 +95,7 @@ jobs:
           flutter test test/unit_tests test/widget --coverage
 
       - name: Generate coverage report 
-        uses: fermi-ad/code-coverage-reporter@v1.1.0
+        uses: fermi-ad/code-coverage-reporter@v1.1.1
         with:
           include_pattern: ^.*\.dart$
           exclude_pattern: test/|\.dart_tool/

--- a/.github/workflows/rust-integration.yaml
+++ b/.github/workflows/rust-integration.yaml
@@ -61,7 +61,7 @@ jobs:
         run: grcov ./target --binary-path ./target/debug/deps/ -s . -t lcov --ignore-not-existing --ignore '../*' --ignore "/*" --ignore "target/**" -o target/lcov.info
 
       - name: Generate coverage report
-        uses: fermi-ad/code-coverage-reporter@v1.1.0
+        uses: fermi-ad/code-coverage-reporter@v1.1.1
         with:
           coverage_file: target/lcov.info
           include_pattern: ^.*\.rs$


### PR DESCRIPTION
Added some debugging output to the code coverage plugin, which should help figure out what's going on when it dies. Will also need to update the Rust integration workflow once the debug output identifies what file is attempting to be read but can't be found in the grpc-alarms-db repo currently.