### PR TITLE
Add ap-python CI-CD workflows

### DIFF
--- a/.github/workflows/ap-python-deployment.yaml
+++ b/.github/workflows/ap-python-deployment.yaml
@@ -1,0 +1,62 @@
+name: AP Python Continuous Delivery
+
+on:
+  workflow_call:
+    inputs:
+      pull-git-submodules:
+        required: false
+        type: boolean
+        default: false
+        description: 'Indicates whether this repository has Git submodules to pull.'
+
+      image-variant:
+        required: false
+        type: string
+        default: gui-xpra
+        description: 'Which container image variant to build and deploy (cli or gui-xpra).'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Build-Dockerize-Push:
+    runs-on: ubuntu-latest
+	
+    steps:
+      - name: Checking out source code
+        uses: actions/checkout@v6
+        with:
+          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: adregistry.fnal.gov/ap-python/${{ github.event.repository.name }}
+          tags: |
+            # This is the default tag for the last commit of the default branch
+            type=edge
+            # This sets the latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.run_number }},enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to AD Registry, Harbor
+        uses: docker/login-action@v4
+        with:
+          registry: adregistry.fnal.gov
+          username: ${{ secrets.ADREGISTRY_AP_USERNAME }}
+          password: ${{ secrets.ADREGISTRY_AP_SECRET }}
+
+      - name: Building Docker image and pushing to adregistry
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          # Build the correct Dockerfile target based on the selected image variant.
+          target: ${{ inputs.image-variant == 'gui-xpra' && 'xpra-runtime' || 'runtime' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ap-python-deployment.yaml
+++ b/.github/workflows/ap-python-deployment.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   Build-Dockerize-Push:
     runs-on: ubuntu-latest
-	
+
     steps:
       - name: Checking out source code
         uses: actions/checkout@v6

--- a/.github/workflows/ap-python-deployment.yaml
+++ b/.github/workflows/ap-python-deployment.yaml
@@ -3,12 +3,6 @@ name: AP Python Continuous Delivery
 on:
   workflow_call:
     inputs:
-      pull-git-submodules:
-        required: false
-        type: boolean
-        default: false
-        description: 'Indicates whether this repository has Git submodules to pull.'
-
       image-variant:
         required: false
         type: string
@@ -26,8 +20,6 @@ jobs:
     steps:
       - name: Checking out source code
         uses: actions/checkout@v6
-        with:
-          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -1,0 +1,90 @@
+name: AP Python Continuous Integration
+
+on:
+  workflow_call:
+    inputs:
+      coverage-exclude:
+        required: false
+        type: string
+        default: ''
+        description: 'Patterns to add to the coverage exclude configuration. Must begin with a pipe (|) character!'
+      pull-git-submodules:
+        required: false
+        type: boolean
+        default: false
+        description: 'Indicates whether this repository has Git submodules to pull.'
+      references-internal-git-repo:
+        required: false
+        type: boolean
+        default: false
+        description: 'Indicates whether this repository has a dependency in its pyproject.toml that comes from an internal GitHub repo'
+      static-dependencies:
+        required: false 
+        type: string
+        default: ''
+        description: 'A space-delimited list of packages that must be installed on the machine for the code to compile'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install static packages
+        run: sudo apt-get update -y && sudo apt-get install -y libkrb5-dev ${{ inputs.static-dependencies }}
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
+
+      - if: ${{ inputs.references-internal-git-repo }}
+        name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.ACTION_SETTINGS_APP_ID }}
+          private-key: ${{ secrets.ACTION_SETTINGS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - if: ${{ inputs.references-internal-git-repo }}
+        name: Configure Git for private repo access
+        run: |
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+        
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          # Enable automatic caching of the uv package store
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv python install && uv sync --locked --all-extras --dev
+      
+      - name: Lint
+        id: linting
+        run: uv run ruff check . 
+        # Ensures we also run the unit tests even if there are linting errors
+        continue-on-error: true
+      
+      - name: Run tests with coverage
+        run: uv run pytest --cov=src --cov-report=lcov:lcov.info
+
+      - name: Generate coverage report
+        uses: fermi-ad/code-coverage-reporter@v2.0.0
+        with:
+          coverage_file: lcov.info
+          include_pattern: src/.*\.py$
+          exclude_pattern: tests/${{ inputs.coverage-exclude }}
+
+      - if: always()
+        name: Report linting results
+        run: |
+          if [ "${{ steps.linting.outcome }}" = "failure" ]; then
+            echo "Failure in linting step. See that step's output for details."
+            exit 1
+          fi

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -6,18 +6,13 @@ on:
       coverage-exclude:
         required: false
         type: string
-        default: ''
-        description: 'Patterns to add to the coverage exclude configuration. Must begin with a pipe (|) character!'
-      pull-git-submodules:
-        required: false
-        type: boolean
-        default: false
-        description: 'Indicates whether this repository has Git submodules to pull.'
+        default: 'tests/'
+        description: 'Patterns to add to the coverage exclude configuration'
       static-dependencies:
         required: false 
         type: string
         default: ''
-        description: 'A space-delimited list of packages that must be installed on the machine for the code to compile'
+        description: 'A space-delimited list of OS packages that must be installed on the machine for the code to compile'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -34,8 +29,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
         
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -13,11 +13,6 @@ on:
         type: boolean
         default: false
         description: 'Indicates whether this repository has Git submodules to pull.'
-      references-internal-git-repo:
-        required: false
-        type: boolean
-        default: false
-        description: 'Indicates whether this repository has a dependency in its pyproject.toml that comes from an internal GitHub repo'
       static-dependencies:
         required: false 
         type: string
@@ -33,27 +28,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install static packages
-        run: sudo apt-get update -y && sudo apt-get install -y libkrb5-dev ${{ inputs.static-dependencies }}
+      - if: ${{ inputs.static-dependencies }}
+        name: Install static packages
+        run: sudo apt-get update -y && sudo apt-get install -y ${{ inputs.static-dependencies }}
 
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
-
-      - if: ${{ inputs.references-internal-git-repo }}
-        name: Generate a token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.ACTION_SETTINGS_APP_ID }}
-          private-key: ${{ secrets.ACTION_SETTINGS_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - if: ${{ inputs.references-internal-git-repo }}
-        name: Configure Git for private repo access
-        run: |
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
         
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -67,7 +49,7 @@ jobs:
       
       - name: Lint
         id: linting
-        run: uv run ruff check . 
+        run: uv run ruff check . >> "$GITHUB_OUTPUT"
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
       
@@ -79,12 +61,12 @@ jobs:
         with:
           coverage_file: lcov.info
           include_pattern: src/.*\.py$
-          exclude_pattern: tests/${{ inputs.coverage-exclude }}
+          exclude_pattern: ${{ inputs.coverage-exclude }}
 
       - if: always()
         name: Report linting results
         run: |
           if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "Failure in linting step. See that step's output for details."
+            echo "${{ steps.linting.output }}"
             exit 1
           fi

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -49,7 +49,8 @@ jobs:
       
       - name: Lint
         id: linting
-        run: uv run ruff check . >> "$GITHUB_OUTPUT"
+        run: |
+            result=$(uv run ruff check .) >> "$GITHUB_OUTPUT"
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
       

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -51,11 +51,9 @@ jobs:
         id: linting
         run: |
             set +e
-            RESULTS=$(uv run ruff check .)
+            RESULTS=$(uv run ruff check . | base64 -w 0)
             CODE=$?
-            echo "lints<<EOF" >> $GITHUB_OUTPUT
-            echo "$RESULTS" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "lints=$RESULTS" >> $GITHUB_OUTPUT
             exit $CODE
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
@@ -74,6 +72,6 @@ jobs:
         name: Report linting results
         run: |
           if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "${{ steps.linting.outputs.lints }}"
+            echo "${{ steps.linting.outputs.lints }}" | base64 -d
             exit 1
           fi

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -50,10 +50,13 @@ jobs:
       - name: Lint
         id: linting
         run: |
+            set +e
             RESULTS=$(uv run ruff check .)
+            CODE=$?
             echo "lints<<EOF" >> $GITHUB_OUTPUT
             echo "$RESULTS" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+            exit $CODE
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
       
@@ -71,6 +74,6 @@ jobs:
         name: Report linting results
         run: |
           if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "${{ steps.linting.output.lints }}"
+            echo "${{ steps.linting.outputs.lints }}"
             exit 1
           fi

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -50,7 +50,10 @@ jobs:
       - name: Lint
         id: linting
         run: |
-            result=$(uv run ruff check .) >> "$GITHUB_OUTPUT"
+            RESULTS=$(uv run ruff check .)
+            echo "lints<<EOF" >> $GITHUB_OUTPUT
+            echo "$RESULTS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
       
@@ -68,6 +71,6 @@ jobs:
         name: Report linting results
         run: |
           if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "${{ steps.linting.output }}"
+            echo "${{ steps.linting.output.lints }}"
             exit 1
           fi

--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -51,9 +51,10 @@ jobs:
         id: linting
         run: |
             set +e
-            RESULTS=$(uv run ruff check . | base64 -w 0)
+            RESULTS=$(uv run ruff check .)
             CODE=$?
-            echo "lints=$RESULTS" >> $GITHUB_OUTPUT
+            ENCODED=$( echo "$RESULTS" | base64 -w 0 )
+            echo "lints=$ENCODED" >> $GITHUB_OUTPUT
             exit $CODE
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true


### PR DESCRIPTION
Added an integration and a delivery workflow for the ap-python repos to use. 

### Integration 
- Generally follows the pattern of the other integration workflows
- Does not include the "uses internal git repo" flag like other projects, as that would require we set up the GH App in each ap-python repo to generate the access token we'd need. These users will just have to rely on git submodules (and even that might not work, so then they are just out of luck, I'd say). 
- Also has an enhancement to the lint reporting step, so the lint output is displayed right there. I'll add the same enhancement to the other workflows in a separate PR. Prevents users from having to scroll up in the workflow details and find the lint step. 

### Delivery
- Has some custom logic here for building an image from the included Dockerfile in the ap-python template
  - Lets users choose if they want a gui or a cli tool. Defaults to gui