### PR TITLE
Make it easier to see lint errors in the pipeline

### DIFF
--- a/.github/workflows/ap-python-integration.yaml
+++ b/.github/workflows/ap-python-integration.yaml
@@ -56,7 +56,7 @@ jobs:
         run: uv run pytest --cov=src --cov-report=lcov:lcov.info
 
       - name: Generate coverage report
-        uses: fermi-ad/code-coverage-reporter@v2.0.0
+        uses: fermi-ad/code-coverage-reporter@v2
         with:
           coverage_file: lcov.info
           include_pattern: src/.*\.py$

--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -137,7 +137,7 @@ jobs:
           flutter test test/unit_tests test/widget --coverage
 
       - name: Generate coverage report 
-        uses: fermi-ad/code-coverage-reporter@v2.0.0
+        uses: fermi-ad/code-coverage-reporter@v2
         with:
           include_pattern: ^.*\.dart$
           exclude_pattern: test/|\.dart_tool/${{ inputs.coverage-exclude }}

--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -109,9 +109,18 @@ jobs:
 
       - name: Resolving dependencies
         run: flutter pub get
-
-      - name: Linting
-        run: flutter analyze .
+      
+      - name: Lint
+        id: linting
+        run: |
+            set +e
+            RESULTS=$(flutter analyze .)
+            CODE=$?
+            ENCODED=$( echo "$RESULTS" | base64 -w 0 )
+            echo "lints=$ENCODED" >> $GITHUB_OUTPUT
+            exit $CODE
+        # Ensures we also run the unit tests even if there are linting errors
+        continue-on-error: true
 
       - name: Building web application
         run: |
@@ -132,3 +141,11 @@ jobs:
         with:
           include_pattern: ^.*\.dart$
           exclude_pattern: test/|\.dart_tool/${{ inputs.coverage-exclude }}
+
+      - if: always()
+        name: Report linting results
+        run: |
+          if [ "${{ steps.linting.outcome }}" = "failure" ]; then
+            echo "${{ steps.linting.outputs.lints }}" | base64 -d
+            exit 1
+          fi

--- a/.github/workflows/rust-integration.yaml
+++ b/.github/workflows/rust-integration.yaml
@@ -108,7 +108,7 @@ jobs:
         run: grcov ./target --binary-path ./target/debug/deps/ -s . -t lcov --ignore-not-existing --ignore '../*' --ignore '/*' --ignore 'target/**' -o target/lcov.info
 
       - name: Generate coverage report
-        uses: fermi-ad/code-coverage-reporter@v2.0.0
+        uses: fermi-ad/code-coverage-reporter@v2
         with:
           coverage_file: target/lcov.info
           include_pattern: src/.*\.rs$

--- a/.github/workflows/rust-integration.yaml
+++ b/.github/workflows/rust-integration.yaml
@@ -68,11 +68,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Lint
         id: linting
-        # Reports warnings if there are unused dependencies in the cargo.toml
-        run: RUSTFLAGS=-Wunused-crate-dependencies cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --all -- --check
+        run: |
+            set +e
+            RESULTS=$(RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings && cargo fmt -q --all -- --check)
+            CODE=$?
+            ENCODED=$( echo "$RESULTS" | base64 -w 0 )
+            echo "lints=$ENCODED" >> $GITHUB_OUTPUT
+            exit $CODE
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
 
@@ -113,6 +118,6 @@ jobs:
         name: Report linting results
         run: |
           if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "Failure in linting step. See that step's output for details."
+            echo "${{ steps.linting.outputs.lints }}" | base64 -d
             exit 1
           fi


### PR DESCRIPTION
Took the enhancements to the linting process I made in #46 and added them to the flutter and rust integration workflows. It captures the output and preserves it to display in the final step, rather than making the developer scroll up to the linting step to see what the problem was.

Once this is merged, I recommend folks update their project workflows at their leisure.

Related - should we just point the downstream workflows at `main` here? Updating commit hashes everywhere is going to start getting out of hand. Open to thoughts!