### PR TITLE
fix: :bug: Fix central resource checkout tracking inside reusable workflows

### DIFF
--- a/.github/workflows/flutter-deploy.yaml
+++ b/.github/workflows/flutter-deploy.yaml
@@ -51,12 +51,18 @@ jobs:
       # the resources from that same tag.
       - name: Determine shared resources ref
         id: shared-resources-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
-          # github.workflow_ref looks like 'owner/repo/.github/workflows/name.yaml@ref'
-          # We extract everything after the '@'
-          echo "ref=${WORKFLOW_REF#*@}" >> "$GITHUB_OUTPUT"
+          # If job.workflow_sha is empty or evaluates to a PR reference from a caller context, 
+          # we safely fall back to the main branch. Otherwise, use the pinned SHA/tag.
+          TARGET_REF="${{ job.workflow_sha }}"
+          
+          if [[ -z "$TARGET_REF" ]] || [[ "$TARGET_REF" == refs/pull/* ]]; then
+            echo "No valid workflow SHA found or PR context detected. Falling back to main branch."
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pinning shared resources to workflow SHA: $TARGET_REF"
+            echo "ref=$TARGET_REF" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout shared resources
         uses: actions/checkout@v6


### PR DESCRIPTION
When workflows are called from an application repository via a Pull Request, relying on string parsing from 'github.workflow_ref' breaks  because it evaluates to the application repository's local context  (e.g., 'refs/pull/3/merge'). This PR ref does not exist inside our  central '.github' infrastructure repository, causing actions/checkout  to crash with a fatal exit code 128.

To align with immutable infrastructure best practices, we need to track  the precise tag or commit SHA of the reusable workflow that the application pinned its deployment to, rather than tracking its local branch state.

We are updating the logic to use GitHub's native 'job' context variables.  According to the GitHub documentation on Contexts:
- 'job.workflow_sha': Evaluates strictly to the commit SHA of the workflow  file that defines the current job. For reusable workflows, this correctly  yields the exact pinned version/SHA of the called workflow.

This prevents breaking changes from propagating down to application repos  pinned to legacy tags, while providing a clean fallback to the main branch  when executed outside of a standard version pin.

Docs Reference:
https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#job-context