### PR TITLE
:sparkles: add app info to Flutter builds

### DIFF
--- a/.github/workflows/flutter-deploy.yaml
+++ b/.github/workflows/flutter-deploy.yaml
@@ -107,9 +107,13 @@ jobs:
             PWA_STRAT="${{ inputs.pwa-strategy }}"
           fi
           
+          echo "Extract App Information"
+          VER=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          NAME=$(grep '^name:' pubspec.yaml | awk '{print $2}')
+
           echo "Building with PWA strategy: $PWA_STRAT"
           flutter pub get
-          flutter build web --no-web-resources-cdn --pwa-strategy=$PWA_STRAT ${{ inputs.use-wasm && '--wasm' || '' }}
+          flutter build web --no-web-resources-cdn --dart-define=APP_VERSION=$VER --dart-define=APP_NAME=$NAME --pwa-strategy=$PWA_STRAT ${{ inputs.use-wasm && '--wasm' || '' }}
 
       - name: Prepare Docker environment
         run: |


### PR DESCRIPTION
The `flutter-controls-core` package now looks in the environment for **`APP_NAME`** and **`APP_VERSION`** to be displayed in the Drawer. This commit makes the build include those values in the environment.