### PR TITLE
Flutter deploy: Remove token from GitHub checkout action

### DIFF
--- a/.github/workflows/flutter-deploy.yaml
+++ b/.github/workflows/flutter-deploy.yaml
@@ -70,7 +70,6 @@ jobs:
           repository: fermi-ad/.github
           path: .shared-resources
           ref: ${{ steps.shared-resources-ref.outputs.ref }}
-          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create an empty environment file that will be over-written later
         run: touch .env


### PR DESCRIPTION
Removed token parameter from the checkout action, .github repository is public.