### PR TITLE
Add configurable base image to workflows

### DIFF
--- a/.github/workflows/flutter-deploy.yaml
+++ b/.github/workflows/flutter-deploy.yaml
@@ -31,6 +31,9 @@ jobs:
       contents: write
       
     steps:
+      # ------------------------------------------
+      # --------------- Initial Setup ------------
+      # ------------------------------------------
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v3
@@ -45,6 +48,108 @@ jobs:
           submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Determine build context
+        run: |
+          if [ -f "lib/main.dart" ]; then
+            echo "BUILD_PATH=." >> $GITHUB_ENV
+          elif [ -f "example/lib/main.dart" ]; then
+            echo "BUILD_PATH=example" >> $GITHUB_ENV
+          else
+            echo "Error: lib/main.dart not found in root or example/"
+            exit 1
+          fi
+          
+      - name: Determine PWA strat 
+        run: |
+          # Determine PWA strategy: force offline-first for main branch
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "PWA_STRAT=offline-first" >> $GITHUB_ENV
+          else
+            echo "PWA_STRAT=${{ inputs.pwa-strategy }}" >> $GITHUB_ENV
+          fi
+          
+      - name: Extract app information
+        run: |
+          cd "${{ env.BUILD_PATH }}"
+          echo "APP_VER=$(grep '^version:' pubspec.yaml | awk '{print $2}')" >> $GITHUB_ENV 
+          echo "APP_NAME=$(grep '^name:' pubspec.yaml | awk '{print $2}')" >> $GITHUB_ENV
+
+      # --------------------------------------------------------------
+      # ---------------- Dev Container Check -------------------------
+      # --------------------------------------------------------------
+
+      - name: Check for dev container 
+        id: dev-container-check
+        run: |
+          if [ -f .devcontainer/devcontainer.json ]; then
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
+      # ----------------------------------------------------------------
+      # ------------------ Dev Container Build -------------------------
+      # ----------------------------------------------------------------
+
+      - name: Build Executable with Dev Container
+        if: ${{ steps.dev-container-check.outputs.present == 'true' }}
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          env: |
+            APP_NAME="${{ env.APP_NAME }}"
+            APP_VER="${{ env.APP_VER }}"
+            BUILD_PATH="${{ env.BUILD_PATH }}"
+            GIT_TOKEN="${{ steps.generate-token.outputs.token }}"
+            PWA_STRAT="${{ env.PWA_STRAT }}"
+            WASM_FLAG="${{ inputs.use-wasm && '--wasm' || '' }}"
+          runCmd: |
+            set -e
+            
+            # Configure access to internal Git repositories
+            if [ -n "$GIT_TOKEN" ]; then 
+              echo "Configuring git API token"
+              git config --file /tmp/git-credentials \
+                url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf \
+                "https://github.com/"
+              export GIT_CONFIG_GLOBAL=/tmp/git-credentials
+            fi
+            
+            echo "=== BUILD FOR RELEASE ==="
+            cd $BUILD_PATH             
+            echo "Building with PWA strategy: ${PWA_STRAT}"
+            flutter pub get
+            flutter build web --no-web-resources-cdn --dart-define=APP_VERSION="$APP_VER" --dart-define=APP_NAME="$APP_NAME" --pwa-strategy="$PWA_STRAT" $WASM_FLAG
+
+      # ----------------------------------------------------------------------
+      # ------------------------ Non-Container Build -------------------------
+      # ----------------------------------------------------------------------
+
+      - name: Non-Container Configure Git for private repo access
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        run: |
+          git config --global url."https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Non-Container Flutter install
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: Non-Container Building web application
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        run: |
+          cd ${{ env.BUILD_PATH }}
+          
+          echo "Building with PWA strategy: ${{ env.PWA_STRAT }}"
+          flutter pub get
+          flutter build web --no-web-resources-cdn --dart-define=APP_VERSION="${{ env.APP_VER }}" --dart-define=APP_NAME="${{ env.APP_NAME }}" --pwa-strategy="${{ env.PWA_STRAT }}" ${{ inputs.use-wasm && '--wasm' || '' }}
+
+      # ----------------------------------------------------------------------
+      # ------------------------ Image Publishing ----------------------------
+      # ----------------------------------------------------------------------
+
       # To ensure reproducibility, we want to fetch the shared resources (nginx config, Dockerfile)
       # from the same version of the '.github' repository that this workflow is running from.
       # If a consumer pins this workflow to a specific tag (e.g., @v1.2.3), we should use
@@ -58,10 +163,10 @@ jobs:
           
           if [[ -z "$TARGET_REF" ]] || [[ "$TARGET_REF" == refs/pull/* ]]; then
             echo "No valid workflow SHA found or PR context detected. Falling back to main branch."
-            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "ref=main" >> $GITHUB_OUTPUT
           else
             echo "Pinning shared resources to workflow SHA: $TARGET_REF"
-            echo "ref=$TARGET_REF" >> "$GITHUB_OUTPUT"
+            echo "ref=$TARGET_REF" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout shared resources
@@ -71,54 +176,11 @@ jobs:
           path: .shared-resources
           ref: ${{ steps.shared-resources-ref.outputs.ref }}
 
-      - name: Create an empty environment file that will be over-written later
-        run: touch .env
-
-      - name: Configure Git for private repo access
-        run: |
-          git config --global url."https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
-          cache: true
-
-      - name: Determine build context
-        id: context
-        run: |
-          if [ -f "lib/main.dart" ]; then
-            echo "path=." >> $GITHUB_OUTPUT
-          elif [ -f "example/lib/main.dart" ]; then
-            echo "path=example" >> $GITHUB_OUTPUT
-          else
-            echo "Error: lib/main.dart not found in root or example/"
-            exit 1
-          fi
-
-      - name: Building web application
-        run: |
-          cd "${{ steps.context.outputs.path }}"
-          
-          # Determine PWA strategy: force offline-first for main branch
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            PWA_STRAT="offline-first"
-          else
-            PWA_STRAT="${{ inputs.pwa-strategy }}"
-          fi
-          
-          echo "Extract App Information"
-          VER=$(grep '^version:' pubspec.yaml | awk '{print $2}')
-          NAME=$(grep '^name:' pubspec.yaml | awk '{print $2}')
-
-          echo "Building with PWA strategy: $PWA_STRAT"
-          flutter pub get
-          flutter build web --no-web-resources-cdn --dart-define=APP_VERSION=$VER --dart-define=APP_NAME=$NAME --pwa-strategy=$PWA_STRAT ${{ inputs.use-wasm && '--wasm' || '' }}
-
       - name: Prepare Docker environment
         run: |
           # Copy the standardized nginx config and Dockerfile into the build context
-          cp .shared-resources/.github/resources/flutter-nginx.conf "${{ steps.context.outputs.path }}/nginx.conf"
-          cp .shared-resources/.github/resources/flutter.Dockerfile "${{ steps.context.outputs.path }}/flutter.Dockerfile"
+          cp .shared-resources/.github/resources/flutter-nginx.conf "${{ env.BUILD_PATH }}/nginx.conf"
+          cp .shared-resources/.github/resources/flutter.Dockerfile "${{ env.BUILD_PATH }}/Dockerfile"
 
       - name: Docker meta
         id: meta
@@ -145,8 +207,7 @@ jobs:
       - name: Building Docker image and pushing to adregistry
         uses: docker/build-push-action@v7
         with:
-          context: ${{ steps.context.outputs.path }}
-          file: ${{ steps.context.outputs.path }}/flutter.Dockerfile
+          context: ${{ env.BUILD_PATH }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -50,13 +50,10 @@ jobs:
             exit 1
           fi
 
-      - name: Create an empty environment file that will be overwritten later
-        run: touch .env
-
       - name: Configure Git for private repo access
         run: |
           git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-          
+
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
@@ -94,35 +91,89 @@ jobs:
         with:
           submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
           token: ${{ steps.app-token.outputs.token }}
-        
-      - name: Create an empty environment file that will be overwritten later
-        run: touch .env
 
       - name: Configure Git for private repo access
         run: |
           git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-          
-      - uses: subosito/flutter-action@v2
+
+      # --------------------------------------------------------------
+      # ---------------- Dev Container Check -------------------------
+      # --------------------------------------------------------------
+
+      - name: Check for dev container 
+        id: dev-container-check
+        run: |
+          if [ -f .devcontainer/devcontainer.json ]; then
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
+      # -----------------------------------------------------------------------------------
+      # ---------------------- Dev Container Pipeline -------------------------------------
+      # -----------------------------------------------------------------------------------
+
+      - name: Build and Run Dev Container
+        id: container-pipeline
+        if: ${{ steps.dev-container-check.outputs.present == 'true' }}
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          env: |
+            GIT_TOKEN=${{ steps.app-token.outputs.token }}
+          runCmd: |
+            set -e
+            
+            # Configure access to internal Git repositories
+            if [ -n "$GIT_TOKEN" ]; then 
+              echo "Configuring git API token"
+              git config --file /tmp/git-credentials \
+                url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf \
+                "https://github.com/"
+              export GIT_CONFIG_GLOBAL=/tmp/git-credentials
+            fi
+            
+            echo "=== RESOLVING DEPENDENCIES ==="
+            flutter pub get
+            
+            echo "=== RUNNING LINTS ==="
+            (flutter analyze .) > lints.txt 2>&1 || (cat lints.txt && exit 1)
+            
+            echo "=== BUILDING WEB APP ==="
+            if [ -f "lib/main.dart" ]; then
+              flutter build web
+            elif [ -f "example/lib/main.dart" ]; then
+              (cd example && flutter pub get && flutter build web)
+            fi
+            
+            echo "=== RUNNING TESTS ==="
+            flutter test test/unit_tests test/widget --coverage
+
+      # -----------------------------------------------------------------------------------
+      # ---------------------- Non-Container Pipeline -------------------------------------
+      # -----------------------------------------------------------------------------------
+
+      - name: Non-Container Flutter install
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        uses: subosito/flutter-action@v2
         with:
           channel: "stable"
           cache: true
 
-      - name: Resolving dependencies
+      - name: Non-Container Resolving dependencies
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
         run: flutter pub get
-      
-      - name: Lint
+
+      - name: Non-Container Lint
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
         id: linting
         run: |
-            set +e
-            RESULTS=$(flutter analyze .)
-            CODE=$?
-            ENCODED=$( echo "$RESULTS" | base64 -w 0 )
-            echo "lints=$ENCODED" >> $GITHUB_OUTPUT
-            exit $CODE
+            (flutter analyze .) > lints.txt 2>&1 || (cat lints.txt && exit 1)
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
 
-      - name: Building web application
+      - name: Non-Container Building web application
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
         run: |
           if [ -f "lib/main.dart" ];
           then
@@ -132,12 +183,24 @@ jobs:
             (cd example && flutter pub get && flutter build web)
           fi
 
-      - name: Running unit and widget tests with coverage
+      - name: Non-Container Running unit and widget tests with coverage
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
         run: |
           flutter test test/unit_tests test/widget --coverage
 
+      # ---------------------------------------------------------------------------------------      
+      # ---------------------- Pipeline Results Reporting -------------------------------------
+      # ---------------------------------------------------------------------------------------    
+
+      - name: Archive Lint Logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lint-results
+          path: lints.txt
+
       - name: Generate coverage report 
-        uses: fermi-ad/code-coverage-reporter@v2
+        uses: fermi-ad/code-coverage-reporter@v3
         with:
           include_pattern: ^.*\.dart$
           exclude_pattern: test/|\.dart_tool/${{ inputs.coverage-exclude }}
@@ -145,7 +208,17 @@ jobs:
       - if: always()
         name: Report linting results
         run: |
-          if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "${{ steps.linting.outputs.lints }}" | base64 -d
-            exit 1
+          if [ "${{ steps.dev-container-check.outputs.present }}" = "true" ]; then
+            if [ "${{ steps.container-pipeline.outcome }}" = "failure" ] && [ ! -f coverage/lcov.info ]; then
+              echo "=== DEV CONTAINER EXECUTION FAILED ==="
+              cat lints.txt || true
+              exit 1
+            fi
+          else
+            if [ "${{ steps.linting.outcome }}" = "failure" ]; then
+              echo "=== LINTING FAILED: PRINTING ERROR LOGS ==="
+              cat lints.txt
+              exit 1
+            fi
           fi
+          echo "Linting and quality verifications passed cleanly!"

--- a/.github/workflows/flutter-integration.yaml
+++ b/.github/workflows/flutter-integration.yaml
@@ -137,7 +137,10 @@ jobs:
             flutter pub get
             
             echo "=== RUNNING LINTS ==="
-            (flutter analyze .) > lints.txt 2>&1 || (cat lints.txt && exit 1)
+            # Runs both the flutter and dart linters, as they return different results sometimes
+            # Both commands use `|| true` so the build and test phase also runs
+            flutter analyze . > lints.txt 2>&1 || true
+            dart analyze . >> lints.txt 2>&1 || true
             
             echo "=== BUILDING WEB APP ==="
             if [ -f "lib/main.dart" ]; then
@@ -168,7 +171,10 @@ jobs:
         if: ${{ steps.dev-container-check.outputs.present == 'false' }}
         id: linting
         run: |
-            (flutter analyze .) > lints.txt 2>&1 || (cat lints.txt && exit 1)
+          flutter analyze . > lints.txt 2>&1
+          flutter_result=$?
+          dart analyze . >> lints.txt 2>&1
+          exit $((flutter_result != 0 ? flutter_result : $?))
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
 

--- a/.github/workflows/rust-deployment.yaml
+++ b/.github/workflows/rust-deployment.yaml
@@ -17,7 +17,7 @@ on:
         required: false 
         type: string
         default: ''
-        description: 'A space-delimited list of packages that must be installed on the machine for the code to compile'
+        description: '**DEPRECATED - have a .devcontainer/devcontainer.json in your repo instead** A space-delimited list of packages that must be installed on the machine for the code to compile'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -29,29 +29,15 @@ env:
 jobs:
   Build-Push:
     runs-on: ubuntu-latest
-    env:
-      CARGO_NET_GIT_FETCH_WITH_CLI: ${{ inputs.references-internal-git-repo }}
 
     steps:
+      # ------------------------------------------
+      # --------------- Initial Setup ------------
+      # ------------------------------------------
+
       - if: ${{ inputs.static-dependencies }}
         name: Install static packages
         run: sudo apt-get update -y && sudo apt-get install -y ${{ inputs.static-dependencies }}
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
-
-      - name: Pull from dependency cache
-        uses: actions/cache@v5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - if: ${{ inputs.references-internal-git-repo }}
         name: Generate a token
@@ -67,8 +53,62 @@ jobs:
         run: |
           git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
-      - name: Build
-        run: cargo build --release --verbose
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
+
+      # --------------------------------------------------------------
+      # ---------------- Dev Container Check -------------------------
+      # --------------------------------------------------------------
+
+      - name: Check for dev container 
+        id: dev-container-check
+        run: |
+          if [ -f .devcontainer/devcontainer.json ]; then
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
+      # ----------------------------------------------------------------
+      # ------------------ Dev Container Build -------------------------
+      # ----------------------------------------------------------------
+
+      - name: Build Executable with Dev Container
+        if: ${{ steps.dev-container-check.outputs.present == 'true' }}
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          env: |
+            CARGO_NET_GIT_FETCH_WITH_CLI=${{ inputs.references-internal-git-repo }}
+            GIT_TOKEN=${{ steps.app-token.outputs.token }}
+          runCmd: |
+            set -e
+            
+            # Configure access to internal Git repositories
+            if [ -n "$GIT_TOKEN" ]; then 
+              echo "Configuring git API token"
+              git config --file /tmp/git-credentials \
+                url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf \
+                "https://github.com/"
+              export GIT_CONFIG_GLOBAL=/tmp/git-credentials
+            fi
+            
+            echo "=== BUILD FOR RELEASE ==="
+            cargo build --release
+
+      # ----------------------------------------------------------------------
+      # ------------------------ Non-Container Build -------------------------
+      # ----------------------------------------------------------------------
+
+      - name: Non-Container Build
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        run: cargo build --release
+
+      # ----------------------------------------------------------------------
+      # ------------------------ Image Publishing ----------------------------
+      # ----------------------------------------------------------------------
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/rust-integration.yaml
+++ b/.github/workflows/rust-integration.yaml
@@ -101,7 +101,10 @@ jobs:
             fi
             
             echo "=== RUNNING LINTS ==="
-            (RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings && cargo fmt -q --all -- --check) > lints.txt 2>&1 || (cat lints.txt && exit 1)
+            # Checks code conventions with clippy and format with cargo fmt
+            # Both commands use `|| true` so the build and test phase also runs
+            RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings > lints.txt 2>&1 || true
+            cargo fmt -q --all -- --check >> lints.txt 2>&1 || true
             
             echo "=== RUNNING TESTS ==="
             cargo llvm-cov --lcov --output-path target/lcov.info
@@ -115,8 +118,10 @@ jobs:
         id: linting
         run: |
             set +e
-            (RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings && cargo fmt -q --all -- --check) > lints.txt 2>&1
-            exit $?
+            RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings > lints.txt 2>&1
+            clippy_result=$?
+            cargo fmt -q --all -- --check >> lints.txt 2>&1
+            exit $(( clippy_result != 0 ? clippy_result : $? ))
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
 

--- a/.github/workflows/rust-integration.yaml
+++ b/.github/workflows/rust-integration.yaml
@@ -22,7 +22,7 @@ on:
         required: false 
         type: string
         default: ''
-        description: 'A space-delimited list of packages that must be installed on the machine for the code to compile'
+        description: '**DEPRECATED - have a .devcontainer/devcontainer.json in your repo instead** A space-delimited list of packages that must be installed on the machine for the code to compile'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,14 +35,13 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: ${{ inputs.references-internal-git-repo }}
 
     steps:
+      # --------------------------------------------------------------------------
+      # ---------------------- Initial Setup -------------------------------------
+      # --------------------------------------------------------------------------
+
       - if: ${{ inputs.static-dependencies }}
         name: Install static packages
         run: sudo apt-get update -y && sudo apt-get install -y ${{ inputs.static-dependencies }}
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
 
       - if: ${{ inputs.references-internal-git-repo }}
         name: Generate a token
@@ -57,58 +56,98 @@ jobs:
         name: Configure Git for private repo access
         run: |
           git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-        
-      - name: Pull from dependency cache
-        uses: actions/cache@v5
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Lint
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: ${{ inputs.pull-git-submodules && 'recursive' || 'false' }}
+
+      # --------------------------------------------------------------------------------
+      # ---------------------- Dev Container Check -------------------------------------
+      # --------------------------------------------------------------------------------
+
+      - name: Check for dev container 
+        id: dev-container-check
+        run: |
+          if [ -f .devcontainer/devcontainer.json ]; then
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
+      # -----------------------------------------------------------------------------------
+      # ---------------------- Dev Container Pipeline -------------------------------------
+      # -----------------------------------------------------------------------------------
+
+      - name: Build and Run Dev Container
+        id: container-pipeline
+        if: ${{ steps.dev-container-check.outputs.present == 'true' }}
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          env: |
+            CARGO_NET_GIT_FETCH_WITH_CLI=${{ inputs.references-internal-git-repo }}
+            GIT_TOKEN=${{ steps.app-token.outputs.token }}
+          runCmd: |
+            set -e
+            
+            # Configure access to internal Git repositories
+            if [ -n "$GIT_TOKEN" ]; then 
+              echo "Configuring git API token"
+              git config --file /tmp/git-credentials \
+                url."https://x-access-token:${GIT_TOKEN}@github.com/".insteadOf \
+                "https://github.com/"
+              export GIT_CONFIG_GLOBAL=/tmp/git-credentials
+            fi
+            
+            echo "=== RUNNING LINTS ==="
+            (RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings && cargo fmt -q --all -- --check) > lints.txt 2>&1 || (cat lints.txt && exit 1)
+            
+            echo "=== RUNNING TESTS ==="
+            cargo llvm-cov --lcov --output-path target/lcov.info
+
+      # -----------------------------------------------------------------------------------
+      # ---------------------- Non-Container Pipeline -------------------------------------
+      # -----------------------------------------------------------------------------------
+
+      - name: Non-Container Lint
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
         id: linting
         run: |
             set +e
-            RESULTS=$(RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings && cargo fmt -q --all -- --check)
-            CODE=$?
-            ENCODED=$( echo "$RESULTS" | base64 -w 0 )
-            echo "lints=$ENCODED" >> $GITHUB_OUTPUT
-            exit $CODE
+            (RUSTFLAGS=-Wunused-crate-dependencies cargo clippy -q --all-targets --all-features -- -D warnings && cargo fmt -q --all -- --check) > lints.txt 2>&1
+            exit $?
         # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
 
       # Rust relies on a Low-Level Virtual Machine (LLVM) to capture coverage, 
       # and some massaging of the output binary is needed to get an LCOV file. 
       # This tool does that processing for us.
-      # NOTE: First checks if grcov is already installed (pulled from cache), and only proceeds if not found
-      # The `&> /dev/null` portion ensures the output of `command -v grcov` is discarded 
-      - name: Install coverage dependencies
-        run: command -v grcov &> /dev/null || cargo install grcov
+      - name: Non-Container Install coverage dependencies
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        run: cargo install cargo-llvm-cov
 
-      - name: Configure rustc so machine code can be read by the coverage reporter
-        run: rustup component add llvm-tools
+      - name: Non-Container Configure rustc so machine code can be read by the coverage reporter
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        run: rustup component add llvm-tools-preview
+
+      - name: Non-Container Run tests with coverage (includes building the project)
+        if: ${{ steps.dev-container-check.outputs.present == 'false' }}
+        run: cargo llvm-cov --lcov --output-path target/lcov.info
       
-      - name: Run tests with coverage (includes building the project)
-        run: CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='target/cargo-test-%p-%m.profraw' cargo test --all-features
+      # ---------------------------------------------------------------------------------------      
+      # ---------------------- Pipeline Results Reporting -------------------------------------
+      # ---------------------------------------------------------------------------------------    
 
-      # Breakdown of the command here:
-      #
-      # grcov ./target                     : Run grcov using profraw files found in the target/ directory
-      # --binary-path ./target/debug/deps/ : Path to the compiled binaries
-      # -s .                               : Source directory
-      # -t lcov                            : Specify output format as lcov
-      # --ignore-not-existing              : Ignore files that may be "referenced" in the compiled binaries but don't actually exist on disk (quirk of the LLVM and gcov)
-      # --ignore '../*' --ignore "/*"      : Ignore references to Rust stdlib and other crates in $HOME/.cargo/
-      # -o target/lcov.info                : Output report to target/lcov.info for use in the next step
-      - name: Process raw coverage data into lcov format
-        run: grcov ./target --binary-path ./target/debug/deps/ -s . -t lcov --ignore-not-existing --ignore '../*' --ignore '/*' --ignore 'target/**' -o target/lcov.info
+      - name: Archive Lint Logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lint-results
+          path: lints.txt
 
       - name: Generate coverage report
-        uses: fermi-ad/code-coverage-reporter@v2
+        uses: fermi-ad/code-coverage-reporter@v3
         with:
           coverage_file: target/lcov.info
           include_pattern: src/.*\.rs$
@@ -117,7 +156,17 @@ jobs:
       - if: always()
         name: Report linting results
         run: |
-          if [ "${{ steps.linting.outcome }}" = "failure" ]; then
-            echo "${{ steps.linting.outputs.lints }}" | base64 -d
-            exit 1
+          if [ "${{ steps.dev-container-check.outputs.present }}" = "true" ]; then
+            if [ "${{ steps.container-pipeline.outcome }}" = "failure" ] && [ ! -f target/lcov.info ]; then
+              echo "=== DEV CONTAINER EXECUTION FAILED ==="
+              cat lints.txt || true
+              exit 1
+            fi
+          else
+            if [ "${{ steps.linting.outcome }}" = "failure" ]; then
+              echo "=== LINTING FAILED: PRINTING ERROR LOGS ==="
+              cat lints.txt
+              exit 1
+            fi
           fi
+          echo "Linting and quality verifications passed cleanly!"


### PR DESCRIPTION
## Make dev container the first-class build environment

This PR teaches our shared GitHub Actions workflows to use a repo's own [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) as the canonical build environment, falling back to the existing runner-based approach only when no dev container is present.

### Why

The existing workflows accumulated complexity over time: environment variables were computed mid-step, lint output was base64-encoded to survive step boundaries, coverage required a multi-step `grcov` ceremony, and the build environment on the runner was subtly different from what developers used locally. Each of these was a small lie — the CI environment was not the same as the development environment, and we papered over the gap with workarounds.

A dev container makes the environment explicit and version-controlled. When a repo ships a `.devcontainer/devcontainer.json`, CI should simply use it. This PR makes that the default path.

### What changed

**All four workflows (`flutter-deploy`, `flutter-integration`, `rust-deployment`, `rust-integration`):**

- Added a `Check for dev container` step that sets a `present` output flag.
- All subsequent build/test/lint steps are conditioned on that flag, branching into a **Dev Container** path (`devcontainers/ci@v0.3`) or a **Non-Container** fallback.
- The dev container path passes secrets as scoped environment variables rather than via global `git config`, reducing credential blast radius.

**Flutter workflows:**

- Build context (`BUILD_PATH`), PWA strategy (`PWA_STRAT`), and app metadata (`APP_VER`, `APP_NAME`) are now extracted early and stored in `$GITHUB_ENV`, making them available to all downstream steps without threading step outputs through every reference.
- Removed `touch .env` steps that created empty files with no purpose.
- The Docker build now copies the shared Dockerfile as `Dockerfile` (not `flutter.Dockerfile`), so `docker/build-push-action` can find it without an explicit `file:` argument — removing an implicit coupling between the copy step and the build step.

**Rust workflows:**

- Replaced the `grcov` pipeline (manual `RUSTFLAGS=-C instrument-coverage` + `LLVM_PROFILE_FILE` + `grcov` post-processing) with a single `cargo llvm-cov --lcov --output-path target/lcov.info` call. Fewer moving parts, same output.
- The `static-dependencies` input is marked `**DEPRECATED**` — repos should declare their build dependencies in a dev container instead.
- `CARGO_NET_GIT_FETCH_WITH_CLI` is scoped to the dev container step rather than the entire job.
- Removed the `actions/cache@v5` Cargo cache step; testing indicated no significant difference in build times due to `cargo` needing to recompile everything anyway

**Both ecosystems:**

- Lint output is now redirected to `lints.txt` and uploaded as a workflow artifact via `actions/upload-artifact@v7`, replacing the fragile base64-encode → store as step output → decode-on-failure pattern. Lint failures print the file directly and exit cleanly.
- `fermi-ad/code-coverage-reporter` bumped from `@v2` to `@v3`.

### The result

Repos with a dev container get a CI environment that matches their local setup. Repos without one continue to work exactly as before. The workflows are easier to read because each section is clearly labelled and the branching is explicit rather than hidden in inline conditionals. Each piece of complexity that was removed was there to compensate for a mismatch between environments — and that mismatch is now gone.