### PR TITLE
:zap: proposed fixes

### DIFF
--- a/.github/workflows/rust-integration.yaml
+++ b/.github/workflows/rust-integration.yaml
@@ -58,16 +58,13 @@ jobs:
         run: |
           git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
         
-      - name: Pull from dependency cache
-        uses: actions/cache@v5
-        continue-on-error: false
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+        
+      - name: Install grcov (pre-compiled binary)
+        uses: taiki-e/install-action@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          tool: grcov
 
       - name: Lint
         id: linting
@@ -78,16 +75,7 @@ jobs:
             ENCODED=$( echo "$RESULTS" | base64 -w 0 )
             echo "lints=$ENCODED" >> $GITHUB_OUTPUT
             exit $CODE
-        # Ensures we also run the unit tests even if there are linting errors
         continue-on-error: true
-
-      # Rust relies on a Low-Level Virtual Machine (LLVM) to capture coverage, 
-      # and some massaging of the output binary is needed to get an LCOV file. 
-      # This tool does that processing for us.
-      # NOTE: First checks if grcov is already installed (pulled from cache), and only proceeds if not found
-      # The `&> /dev/null` portion ensures the output of `command -v grcov` is discarded 
-      - name: Install coverage dependencies
-        run: command -v grcov &> /dev/null || cargo install grcov
 
       - name: Configure rustc so machine code can be read by the coverage reporter
         run: rustup component add llvm-tools
@@ -95,15 +83,6 @@ jobs:
       - name: Run tests with coverage (includes building the project)
         run: CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='target/cargo-test-%p-%m.profraw' cargo test --all-features
 
-      # Breakdown of the command here:
-      #
-      # grcov ./target                     : Run grcov using profraw files found in the target/ directory
-      # --binary-path ./target/debug/deps/ : Path to the compiled binaries
-      # -s .                               : Source directory
-      # -t lcov                            : Specify output format as lcov
-      # --ignore-not-existing              : Ignore files that may be "referenced" in the compiled binaries but don't actually exist on disk (quirk of the LLVM and gcov)
-      # --ignore '../*' --ignore "/*"      : Ignore references to Rust stdlib and other crates in $HOME/.cargo/
-      # -o target/lcov.info                : Output report to target/lcov.info for use in the next step
       - name: Process raw coverage data into lcov format
         run: grcov ./target --binary-path ./target/debug/deps/ -s . -t lcov --ignore-not-existing --ignore '../*' --ignore '/*' --ignore 'target/**' -o target/lcov.info
 


### PR DESCRIPTION
This was generated by Gemini. It proposes to fix two issues with the previous version:

- It built the code coverage executable each time it was run. Since the utility is written in Rust, it added quite a bit of time to the workflow.
- It unpacked and rebuilt the cache each time, yet I've never saw it use the contents. I've only ever seen it  unconditionally build the Rust project (twice! once for clippy and for the unit tests)

Gemini proposes that this version uses the cache properly, so it should only rebuild crates that are updated. It also uses a workflow that has a prebuilt instance of the code coverage tool so we don't need to build it over and over.

This PR is being made to share the changes with others that are more familiar with GitHub workflows. It looks good to me, but that's not saying much.